### PR TITLE
Python: Division

### DIFF
--- a/Python Division.ipynb
+++ b/Python Division.ipynb
@@ -1,0 +1,94 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "28a63deb-461d-4fd0-bddf-9de08373bab4",
+   "metadata": {},
+   "source": [
+    "# Python: Division"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "784346a8-054a-4881-8923-514347b97ce1",
+   "metadata": {},
+   "source": [
+    "Task\n",
+    "The provided code stub reads two integers, a and b, from STDIN.\n",
+    "\n",
+    "Add logic to print two lines. The first line should contain the result of integer division, a // b. The second line should contain the result of float division, a / b.\n",
+    "\n",
+    "No rounding or formatting is necessary.\n",
+    "\n",
+    "Example\n",
+    "a = 3\n",
+    "b = 5\n",
+    "\n",
+    "The result of the integer division 3 // 5 = 0.\n",
+    "The result of the float division is 3 / 5 = 0.6.\n",
+    "Print:\n",
+    "\n",
+    "0\n",
+    "0.6\n",
+    "Input Format\n",
+    "\n",
+    "The first line contains the first integer, a.\n",
+    "The second line contains the second integer, b.\n",
+    "\n",
+    "Output Format\n",
+    "\n",
+    "Print the two lines as described above.\n",
+    "\n",
+    "Sample Input 0\n",
+    "\n",
+    "4\n",
+    "3\n",
+    "Sample Output 0\n",
+    "\n",
+    "1\n",
+    "1.33333333333"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "275b89b0-125f-420f-9ee0-46bd36054fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if __name__ == '__main__':\n",
+    "    a = int(input())\n",
+    "    b = int(input())\n",
+    "    print(a // b, a / b, sep = \"\\n\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Task
The provided code stub reads two integers, a and b, from STDIN.

Add logic to print two lines. The first line should contain the result of integer division, a // b. The second line should contain the result of float division, a / b.

No rounding or formatting is necessary.

Example
a = 3
b = 5

The result of the integer division 3 // 5 = 0.
The result of the float division is 3 / 5 = 0.6.
Print:

0
0.6
Input Format

The first line contains the first integer, a.
The second line contains the second integer, b.

Output Format

Print the two lines as described above.

Sample Input 0

4
3
Sample Output 0

1
1.33333333333